### PR TITLE
docs: fix typo in actions list

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Elle est pensée pour être utilisée par les équipes support, infogérance ou 
 *(à compléter avec tes autres outils, par exemple)*
 - Vérification des symlinks Outlook.
 - Export des utilisateurs et groupes locaux/AD.
-- Nettoyage d’espaces disque.
+ - Nettoyage d’espace disque.
 - Contrôle des comptes RDP autorisés.
 
 ---


### PR DESCRIPTION
## Summary
- fix spacing error in README actions list

## Testing
- `grep -n espace README.md`


------
https://chatgpt.com/codex/tasks/task_b_686e2e6eb3b08327862b9b93c418acd6