### PR TITLE
Add Pester tests for menu functions

### DIFF
--- a/Tests/MenuConfig.Tests.ps1
+++ b/Tests/MenuConfig.Tests.ps1
@@ -1,0 +1,26 @@
+$ScriptDir = Split-Path -Parent $PSCommandPath
+$configPath = Join-Path $ScriptDir '..' 'Config' 'config_menu.yaml'
+$optionsDir = Join-Path $ScriptDir '..' 'Options'
+
+# Ensure ConvertFrom-Yaml is available
+if (-not (Get-Command ConvertFrom-Yaml -ErrorAction SilentlyContinue)) {
+    try {
+        Install-Module -Name powershell-yaml -Force -Scope CurrentUser -SkipPublisherCheck
+        Import-Module powershell-yaml
+    } catch {
+        Write-Host "Failed to import powershell-yaml: $_" -ForegroundColor Red
+    }
+}
+
+$config = Get-Content $configPath -Raw -Encoding UTF8 | ConvertFrom-Yaml
+$functions = $config.MenuOptions | ForEach-Object { $_.function }
+
+Get-ChildItem $optionsDir -Filter '*.ps1' | ForEach-Object { . $_.FullName }
+
+Describe 'Menu configuration functions' {
+    foreach ($func in $functions) {
+        It "Function $func should be defined" {
+            Get-Command $func -ErrorAction SilentlyContinue | Should -Not -BeNullOrEmpty
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add new `Tests` folder
- ensure each function in `config_menu.yaml` has an available implementation by adding `MenuConfig.Tests.ps1`

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Path Tests"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_686e2fccef208327b2d356fbdc752c4a